### PR TITLE
Default Message API support (text only)

### DIFF
--- a/appstoreserverlibrary/api_client.py
+++ b/appstoreserverlibrary/api_client.py
@@ -34,6 +34,7 @@ from .models.TransactionInfoResponse import TransactionInfoResponse
 from .models.UpdateAppAccountTokenRequest import UpdateAppAccountTokenRequest
 from .models.UploadMessageRequestBody import UploadMessageRequestBody
 from .models.GetMessageListResponse import GetMessageListResponse
+from .models.DefaultConfigurationRequest import DefaultConfigurationRequest
 
 T = TypeVar('T')
 
@@ -506,6 +507,27 @@ class APIError(IntEnum):
     https://developer.apple.com/documentation/retentionmessaging/messagealreadyexistserror
     """
 
+    INVALID_LOCALE_ERROR = 4000164
+    """
+    An error that indicates the locale is invalid.
+
+    https://developer.apple.com/documentation/retentionmessaging/invalidlocaleerror
+    """
+
+    MESSAGE_NOT_APPROVED_ERROR = 4030017
+    """
+    An error that indicates the message isn't in the approved state, so you can't configure it as a default message.
+
+    https://developer.apple.com/documentation/retentionmessaging/messagenotapprovederror
+    """
+
+    IMAGE_NOT_APPROVED_ERROR = 4030018
+    """
+    An error that indicates the image isn't in the approved state, so you can't configure it as part of a default message.
+
+    https://developer.apple.com/documentation/retentionmessaging/imagenotapprovederror
+    """
+
 
 @define
 class APIException(Exception):
@@ -834,6 +856,29 @@ class AppStoreServerAPIClient(BaseAppStoreServerAPIClient):
         """
         self._make_request("/inApps/v1/messaging/message/" + message_identifier, "DELETE", {}, None, None)
 
+    def configure_default_retention_message(self, product_id: str, locale: str, default_configuration_request: DefaultConfigurationRequest) -> None:
+        """
+        Configure a default message for a specific product in a specific locale.
+        https://developer.apple.com/documentation/retentionmessaging/configure-default-message
+
+        :param product_id: The product identifier for the default configuration.
+        :param locale: The locale for the default configuration (e.g., "en-US").
+        :param default_configuration_request: The request body containing the message identifier to configure as the default message.
+        :raises APIException: If a response was returned indicating the request could not be processed
+        """
+        self._make_request("/inApps/v1/messaging/default/" + product_id + "/" + locale, "PUT", {}, default_configuration_request, None)
+
+    def delete_default_retention_message(self, product_id: str, locale: str) -> None:
+        """
+        Delete a default message for a product in a locale.
+        https://developer.apple.com/documentation/retentionmessaging/delete-default-message
+
+        :param product_id: The product ID of the default message configuration.
+        :param locale: The locale of the default message configuration (e.g., "en-US").
+        :raises APIException: If a response was returned indicating the request could not be processed
+        """
+        self._make_request("/inApps/v1/messaging/default/" + product_id + "/" + locale, "DELETE", {}, None, None)
+
 class AsyncAppStoreServerAPIClient(BaseAppStoreServerAPIClient):
     def __init__(self, signing_key: bytes, key_id: str, issuer_id: str, bundle_id: str, environment: Environment):
         super().__init__(signing_key=signing_key, key_id=key_id, issuer_id=issuer_id, bundle_id=bundle_id, environment=environment)
@@ -1077,3 +1122,26 @@ class AsyncAppStoreServerAPIClient(BaseAppStoreServerAPIClient):
         :raises APIException: If a response was returned indicating the request could not be processed
         """
         await self._make_request("/inApps/v1/messaging/message/" + message_identifier, "DELETE", {}, None, None)
+
+    async def configure_default_retention_message(self, product_id: str, locale: str, default_configuration_request: DefaultConfigurationRequest) -> None:
+        """
+        Configure a default message for a specific product in a specific locale.
+        https://developer.apple.com/documentation/retentionmessaging/configure-default-message
+
+        :param product_id: The product identifier for the default configuration.
+        :param locale: The locale for the default configuration (e.g., "en-US").
+        :param default_configuration_request: The request body containing the message identifier to configure as the default message.
+        :raises APIException: If a response was returned indicating the request could not be processed
+        """
+        await self._make_request("/inApps/v1/messaging/default/" + product_id + "/" + locale, "PUT", {}, default_configuration_request, None)
+
+    async def delete_default_retention_message(self, product_id: str, locale: str) -> None:
+        """
+        Delete a default message for a product in a locale.
+        https://developer.apple.com/documentation/retentionmessaging/delete-default-message
+
+        :param product_id: The product ID of the default message configuration.
+        :param locale: The locale of the default message configuration (e.g., "en-US").
+        :raises APIException: If a response was returned indicating the request could not be processed
+        """
+        await self._make_request("/inApps/v1/messaging/default/" + product_id + "/" + locale, "DELETE", {}, None, None)

--- a/appstoreserverlibrary/models/DefaultConfigurationRequest.py
+++ b/appstoreserverlibrary/models/DefaultConfigurationRequest.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional
+from attr import define
+import attr
+
+@define
+class DefaultConfigurationRequest:
+    """
+    The request body that contains the default configuration information.
+
+    https://developer.apple.com/documentation/retentionmessaging/defaultconfigurationrequest
+    """
+
+    messageIdentifier: Optional[str] = attr.ib(default=None)
+    """
+    The message identifier of the message to configure as a default message.
+
+    https://developer.apple.com/documentation/retentionmessaging/messageidentifier
+    """

--- a/cli/README.md
+++ b/cli/README.md
@@ -82,6 +82,54 @@ python retention_message.py \
   --message-id "my-campaign-001"
 ```
 
+#### Configure Default Messages
+
+Set a message as the default for a specific product and locale. The default message is shown when the real-time messaging flow isn't available or fails.
+
+**Single Product:**
+```bash
+python retention_message.py \
+  --key-id "ABCDEFGHIJ" \
+  --issuer-id "12345678-1234-1234-1234-123456789012" \
+  --bundle-id "com.example.myapp" \
+  --p8-file "/path/to/key.p8" \
+  --action set-default \
+  --message-id "my-campaign-001" \
+  --product-id "com.example.premium" \
+  --locale "en-US"
+```
+
+**Multiple Products (Bulk Operation):**
+```bash
+python retention_message.py \
+  --key-id "ABCDEFGHIJ" \
+  --issuer-id "12345678-1234-1234-1234-123456789012" \
+  --bundle-id "com.example.myapp" \
+  --p8-file "/path/to/key.p8" \
+  --action set-default \
+  --message-id "my-campaign-001" \
+  --product-id "com.example.premium" \
+  --product-id "com.example.basic" \
+  --product-id "com.example.pro" \
+  --locale "en-US"
+```
+
+#### Delete Default Message Configuration
+
+Remove the default message configuration for one or more products:
+
+```bash
+python retention_message.py \
+  --key-id "ABCDEFGHIJ" \
+  --issuer-id "12345678-1234-1234-1234-123456789012" \
+  --bundle-id "com.example.myapp" \
+  --p8-file "/path/to/key.p8" \
+  --action delete-default \
+  --product-id "com.example.premium" \
+  --product-id "com.example.basic" \
+  --locale "en-US"
+```
+
 ### Environment Options
 
 By default, the tool uses the **SANDBOX** environment. For production:
@@ -143,10 +191,14 @@ The tool provides clear error messages for common issues:
 
 | Error Code | Description | Solution |
 |------------|-------------|----------|
+| 4000023 | Invalid product ID | Verify product ID exists in App Store Connect |
+| 4000164 | Invalid locale | Use valid locale code (e.g., "en-US", "fr-FR") |
 | 4010001 | Header text too long | Reduce header to ≤66 characters |
 | 4010002 | Body text too long | Reduce body to ≤144 characters |
 | 4010003 | Alt text too long | Reduce alt text to ≤150 characters |
 | 4010004 | Maximum messages reached | Delete old messages first |
+| 4030017 | Message not approved | Wait for Apple approval before setting as default |
+| 4030018 | Image not approved | Wait for Apple approval of associated image |
 | 4040001 | Message not found | Check message ID spelling |
 | 4090001 | Message ID already exists | Use a different message ID |
 
@@ -198,6 +250,30 @@ python retention_message.py --message-id "holiday-2023" \
 # Back to school
 python retention_message.py --message-id "back-to-school-2023" \
   --header "Ready to learn?" --body "New study tools available" # ... other params
+```
+
+#### Setting Default Messages Across Multiple Tiers
+
+Apply the same message to all subscription tiers in a single command:
+
+```bash
+python retention_message.py \
+  --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
+  --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
+  --action set-default --message-id "general-retention-v1" \
+  --product-id "com.example.basic" \
+  --product-id "com.example.premium" \
+  --product-id "com.example.pro" \
+  --locale "en-US"
+```
+
+Output for bulk operations:
+```
+✓ Default message configured successfully for 3 product(s)!
+  Environment: SANDBOX
+  Message ID: general-retention-v1
+  Locale:     en-US
+  Products:   com.example.basic, com.example.premium, com.example.pro
 ```
 
 ### Integration with CI/CD

--- a/tests/resources/models/invalidLocaleError.json
+++ b/tests/resources/models/invalidLocaleError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000164,
+  "errorMessage": "Invalid request. Locale is invalid."
+}

--- a/tests/resources/models/messageNotApprovedError.json
+++ b/tests/resources/models/messageNotApprovedError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4030017,
+  "errorMessage": "The message isn't approved."
+}


### PR DESCRIPTION
This PR adds support for setting a default message. At the moment only text-based default messages are supported, images will be added in a future PR.

upstream PR here: https://github.com/apple/app-store-server-library-python/pull/157