### PR TITLE
Add retention message image support

### DIFF
--- a/appstoreserverlibrary/models/GetImageListResponse.py
+++ b/appstoreserverlibrary/models/GetImageListResponse.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional, List
+from attr import define
+import attr
+from .GetImageListResponseItem import GetImageListResponseItem
+
+@define
+class GetImageListResponse:
+    """
+    A response that contains status information for all images.
+
+    https://developer.apple.com/documentation/retentionmessaging/getimagelistresponse
+    """
+
+    imageIdentifiers: Optional[List[GetImageListResponseItem]] = attr.ib(default=None)
+    """
+    An array of all image identifiers and their image state.
+
+    https://developer.apple.com/documentation/retentionmessaging/getimagelistresponseitem
+    """

--- a/appstoreserverlibrary/models/GetImageListResponseItem.py
+++ b/appstoreserverlibrary/models/GetImageListResponseItem.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional
+from attr import define
+import attr
+from .ImageState import ImageState
+from .LibraryUtility import AttrsRawValueAware
+
+@define
+class GetImageListResponseItem(AttrsRawValueAware):
+    """
+    An image identifier and state information for an image.
+
+    https://developer.apple.com/documentation/retentionmessaging/getimagelistresponseitem
+    """
+
+    imageIdentifier: Optional[str] = attr.ib(default=None)
+    """
+    The identifier of the image.
+
+    https://developer.apple.com/documentation/retentionmessaging/imageidentifier
+    """
+
+    imageState: Optional[ImageState] = ImageState.create_main_attr('rawImageState')
+    """
+    The current state of the image.
+
+    https://developer.apple.com/documentation/retentionmessaging/imagestate
+    """
+
+    rawImageState: Optional[str] = ImageState.create_raw_attr('imageState')
+    """
+    See imageState
+    """

--- a/appstoreserverlibrary/models/ImageState.py
+++ b/appstoreserverlibrary/models/ImageState.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from enum import Enum
+from .LibraryUtility import AppStoreServerLibraryEnumMeta
+
+class ImageState(Enum, metaclass=AppStoreServerLibraryEnumMeta):
+    """
+    The approval state of an image.
+
+    https://developer.apple.com/documentation/retentionmessaging/imagestate
+    """
+
+    PENDING = "PENDING"
+    """
+    The image is awaiting approval.
+    """
+
+    APPROVED = "APPROVED"
+    """
+    The image is approved.
+    """
+
+    REJECTED = "REJECTED"
+    """
+    The image is rejected.
+    """

--- a/appstoreserverlibrary/models/UploadMessageImage.py
+++ b/appstoreserverlibrary/models/UploadMessageImage.py
@@ -12,16 +12,16 @@ class UploadMessageImage:
     https://developer.apple.com/documentation/retentionmessaging/uploadmessageimage
     """
 
-    imageIdentifier: Optional[str] = attr.ib(default=None)
+    imageIdentifier: str = attr.ib()
     """
-    The unique identifier of an image.
+    **Required.** The unique identifier of an image.
 
     https://developer.apple.com/documentation/retentionmessaging/imageidentifier
     """
 
-    altText: Optional[str] = attr.ib(default=None)
+    altText: str = attr.ib()
     """
-    The alternative text you provide for the corresponding image.
+    **Required.** The alternative text you provide for the corresponding image.
     Maximum length: 150
 
     https://developer.apple.com/documentation/retentionmessaging/alttext

--- a/appstoreserverlibrary/models/UploadMessageRequestBody.py
+++ b/appstoreserverlibrary/models/UploadMessageRequestBody.py
@@ -13,17 +13,17 @@ class UploadMessageRequestBody:
     https://developer.apple.com/documentation/retentionmessaging/uploadmessagerequestbody
     """
 
-    header: Optional[str] = attr.ib(default=None)
+    header: str = attr.ib()
     """
-    The header text of the retention message that the system displays to customers.
+    **Required.** The header text of the retention message that the system displays to customers.
     Maximum length: 66
 
     https://developer.apple.com/documentation/retentionmessaging/header
     """
 
-    body: Optional[str] = attr.ib(default=None)
+    body: str = attr.ib()
     """
-    The body text of the retention message that the system displays to customers.
+    **Required.** The body text of the retention message that the system displays to customers.
     Maximum length: 144
 
     https://developer.apple.com/documentation/retentionmessaging/body

--- a/cli/README.md
+++ b/cli/README.md
@@ -30,8 +30,8 @@ python retention_message.py \
   --issuer-id "12345678-1234-1234-1234-123456789012" \
   --bundle-id "com.example.myapp" \
   --p8-file "/path/to/SubscriptionKey_ABCDEFGHIJ.p8" \
-  --header "Welcome back!" \
-  --body "Check out our new features"
+  --header "Don't miss out!" \
+  --body "Keep enjoying unlimited access to all premium content"
 ```
 
 Upload with a specific message ID:
@@ -41,9 +41,9 @@ python retention_message.py \
   --issuer-id "12345678-1234-1234-1234-123456789012" \
   --bundle-id "com.example.myapp" \
   --p8-file "/path/to/key.p8" \
-  --message-id "my-campaign-001" \
-  --header "Limited Time Sale!" \
-  --body "50% off premium features this week"
+  --message-id "550e8400-e29b-41d4-a716-446655440001" \
+  --header "Stay subscribed and save" \
+  --body "Your subscription gives you access to exclusive features"
 ```
 
 Upload with an image:
@@ -53,10 +53,11 @@ python retention_message.py \
   --issuer-id "12345678-1234-1234-1234-123456789012" \
   --bundle-id "com.example.myapp" \
   --p8-file "/path/to/key.p8" \
-  --header "New Update!" \
-  --body "Amazing new features await" \
-  --image-id "banner-v2" \
-  --image-alt-text "App update banner showing new features"
+  --message-id "550e8400-e29b-41d4-a716-446655440002" \
+  --header "You'll lose access to" \
+  --body "Premium content, ad-free experience, and exclusive features" \
+  --image-id "6ba7b810-9dad-11d1-80b4-00c04fd430c8" \
+  --image-alt-text "Visual showing premium features and content library"
 ```
 
 #### List All Messages
@@ -79,7 +80,7 @@ python retention_message.py \
   --bundle-id "com.example.myapp" \
   --p8-file "/path/to/key.p8" \
   --action delete \
-  --message-id "my-campaign-001"
+  --message-id "550e8400-e29b-41d4-a716-446655440001"
 ```
 
 #### Configure Default Messages
@@ -94,7 +95,7 @@ python retention_message.py \
   --bundle-id "com.example.myapp" \
   --p8-file "/path/to/key.p8" \
   --action set-default \
-  --message-id "my-campaign-001" \
+  --message-id "550e8400-e29b-41d4-a716-446655440003" \
   --product-id "com.example.premium" \
   --locale "en-US"
 ```
@@ -107,7 +108,7 @@ python retention_message.py \
   --bundle-id "com.example.myapp" \
   --p8-file "/path/to/key.p8" \
   --action set-default \
-  --message-id "my-campaign-001" \
+  --message-id "550e8400-e29b-41d4-a716-446655440003" \
   --product-id "com.example.premium" \
   --product-id "com.example.basic" \
   --product-id "com.example.pro" \
@@ -129,6 +130,146 @@ python retention_message.py \
   --product-id "com.example.basic" \
   --locale "en-US"
 ```
+
+### Image Operations
+
+Images can be uploaded and associated with text-based retention messages to make them more visually engaging.
+
+#### Upload an Image
+
+Upload a PNG image for use in retention messages with auto-generated ID:
+
+```bash
+python retention_message.py \
+  --key-id "ABCDEFGHIJ" \
+  --issuer-id "12345678-1234-1234-1234-123456789012" \
+  --bundle-id "com.example.myapp" \
+  --p8-file "/path/to/key.p8" \
+  --action upload-image \
+  --image-file "/path/to/premium_features_banner.png"
+```
+
+Upload with a specific image ID:
+
+```bash
+python retention_message.py \
+  --key-id "ABCDEFGHIJ" \
+  --issuer-id "12345678-1234-1234-1234-123456789012" \
+  --bundle-id "com.example.myapp" \
+  --p8-file "/path/to/key.p8" \
+  --action upload-image \
+  --image-id "6ba7b810-9dad-11d1-80b4-00c04fd430c8" \
+  --image-file "/path/to/premium_features_banner.png"
+```
+
+**Image Requirements:**
+- **Format**: PNG only
+- **Dimensions**: Exactly 3840 × 2160 pixels
+- **Transparency**: Not allowed
+- **Maximum images**: 2000 per app
+
+After upload, images are in **PENDING** state awaiting Apple approval. In SANDBOX, they're auto-approved.
+
+#### List All Images
+
+Check the status of all uploaded images:
+
+```bash
+python retention_message.py \
+  --key-id "ABCDEFGHIJ" \
+  --issuer-id "12345678-1234-1234-1234-123456789012" \
+  --bundle-id "com.example.myapp" \
+  --p8-file "/path/to/key.p8" \
+  --action list-images
+```
+
+Output:
+```
+Found 2 retention image(s) in SANDBOX:
+
+  Image ID: banner-2024-q1
+  State:    APPROVED
+
+  Image ID: promo-summer
+  State:    PENDING
+```
+
+#### Delete an Image
+
+Delete a previously uploaded image (must not be in use by any message):
+
+```bash
+python retention_message.py \
+  --key-id "ABCDEFGHIJ" \
+  --issuer-id "12345678-1234-1234-1234-123456789012" \
+  --bundle-id "com.example.myapp" \
+  --p8-file "/path/to/key.p8" \
+  --action delete-image \
+  --image-id "6ba7b810-9dad-11d1-80b4-00c04fd430c7"
+```
+
+**Important**: You must delete any messages that reference an image before you can delete the image itself.
+
+#### Complete Workflow: Message with Image
+
+Here's the complete workflow for creating a retention message with an image:
+
+```bash
+# Step 1: Upload the image
+python retention_message.py \
+  --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
+  --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
+  --action upload-image \
+  --image-id "7ba7b810-9dad-11d1-80b4-00c04fd430c9" \
+  --image-file "./images/premium_benefits_showcase.png"
+
+# Step 2: Check image approval status (skip in SANDBOX as it's auto-approved)
+python retention_message.py \
+  --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
+  --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
+  --action list-images
+
+# Step 3: Upload a message that references the image
+# Note: Both --header and --body are REQUIRED
+# Note: --image-id and --image-alt-text must be provided together
+python retention_message.py \
+  --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
+  --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
+  --action upload \
+  --message-id "650e8400-e29b-41d4-a716-446655440040" \
+  --header "Keep all your benefits" \
+  --body "Continue enjoying unlimited streaming and exclusive content" \
+  --image-id "7ba7b810-9dad-11d1-80b4-00c04fd430c9" \
+  --image-alt-text "Collage of premium features including ad-free streaming and exclusive shows"
+
+# Step 4: Set as default for products (optional)
+python retention_message.py \
+  --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
+  --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
+  --action set-default \
+  --message-id "650e8400-e29b-41d4-a716-446655440040" \
+  --product-id "com.example.premium" \
+  --locale "en-US"
+```
+
+#### Image States
+
+Images can be in one of three states:
+- **PENDING**: Image uploaded and awaiting Apple's review
+- **APPROVED**: Image approved and can be used in messages
+- **REJECTED**: Image rejected and cannot be used
+
+Both the message and its associated image must be in **APPROVED** state before the system can display them.
+
+#### Image Error Codes
+
+| Error Code | Description | Solution |
+|------------|-------------|----------|
+| 4000104 | Invalid image | Ensure PNG format, 3840×2160 pixels, no transparency |
+| 4030002 | Image in use | Delete messages using this image first |
+| 4030019 | Maximum images reached | Delete unused images (limit: 2000) |
+| 4040002 | Image not found | Check image ID spelling |
+| 4090002 | Image ID already exists | Use a different image ID |
 
 ### Environment Options
 
@@ -179,11 +320,18 @@ Messages can be in one of three states:
 
 ### Constraints and Limits
 
-- **Header text**: Maximum 66 characters
-- **Body text**: Maximum 144 characters
-- **Image alt text**: Maximum 150 characters
-- **Message ID**: Must be unique (UUIDs recommended)
-- **Total messages**: Limited number per app (see Apple's documentation)
+**Required Fields (for upload action):**
+- **Header text**: REQUIRED - Maximum 66 characters
+- **Body text**: REQUIRED - Maximum 144 characters
+
+**Optional Fields:**
+- **Image reference**: Optional - Use `--image-id` and `--image-alt-text` together
+- **Image alt text**: Maximum 150 characters (required if image is included)
+- **Message ID**: Must be unique (UUIDs recommended, auto-generated if not provided)
+
+**System Limits:**
+- **Total messages**: 2000 per app
+- **Total images**: 2000 per app
 
 ### Error Handling
 
@@ -232,24 +380,40 @@ The tool provides clear error messages for common issues:
 
 #### A/B Testing Messages
 ```bash
-# Upload message A
-python retention_message.py --message-id "test-a-v1" \
-  --header "Come back!" --body "We miss you" # ... other params
+# Upload message A - Emotional appeal
+python retention_message.py \
+  --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
+  --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
+  --message-id "550e8400-e29b-41d4-a716-446655440010" \
+  --header "We value your membership" \
+  --body "Continue enjoying premium benefits and exclusive content"
 
-# Upload message B
-python retention_message.py --message-id "test-b-v1" \
-  --header "New features!" --body "Check out what's new" # ... other params
+# Upload message B - Value-focused
+python retention_message.py \
+  --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
+  --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
+  --message-id "550e8400-e29b-41d4-a716-446655440011" \
+  --header "Keep your premium access" \
+  --body "Ad-free experience, offline downloads, and more"
 ```
 
 #### Seasonal Campaigns
 ```bash
-# Holiday campaign
-python retention_message.py --message-id "holiday-2023" \
-  --header "Holiday Sale!" --body "Limited time: 40% off premium" # ... other params
+# Holiday campaign - Highlight seasonal content
+python retention_message.py \
+  --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
+  --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
+  --message-id "550e8400-e29b-41d4-a716-446655440020" \
+  --header "Holiday content awaits" \
+  --body "Stay subscribed for exclusive seasonal features"
 
-# Back to school
-python retention_message.py --message-id "back-to-school-2023" \
-  --header "Ready to learn?" --body "New study tools available" # ... other params
+# Back to school - Educational content retention
+python retention_message.py \
+  --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
+  --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
+  --message-id "550e8400-e29b-41d4-a716-446655440021" \
+  --header "Your learning continues" \
+  --body "Keep accessing study tools and educational resources"
 ```
 
 #### Setting Default Messages Across Multiple Tiers
@@ -260,7 +424,8 @@ Apply the same message to all subscription tiers in a single command:
 python retention_message.py \
   --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
   --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
-  --action set-default --message-id "general-retention-v1" \
+  --action set-default \
+  --message-id "550e8400-e29b-41d4-a716-446655440030" \
   --product-id "com.example.basic" \
   --product-id "com.example.premium" \
   --product-id "com.example.pro" \
@@ -271,7 +436,7 @@ Output for bulk operations:
 ```
 ✓ Default message configured successfully for 3 product(s)!
   Environment: SANDBOX
-  Message ID: general-retention-v1
+  Message ID: 550e8400-e29b-41d4-a716-446655440030
   Locale:     en-US
   Products:   com.example.basic, com.example.premium, com.example.pro
 ```
@@ -285,10 +450,12 @@ For automated deployments, use JSON output:
 RESULT=$(python retention_message.py --json --action upload \
   --key-id "$KEY_ID" --issuer-id "$ISSUER_ID" \
   --bundle-id "$BUNDLE_ID" --p8-file "$P8_FILE" \
-  --header "Auto-deployed message" --body "Latest features")
+  --message-id "750e8400-e29b-41d4-a716-446655440050" \
+  --header "Stay connected" \
+  --body "Keep your subscription active for uninterrupted access")
 
 if echo "$RESULT" | jq -e '.status == "success"' > /dev/null; then
-  echo "Message deployed successfully"
+  echo "Retention message deployed successfully"
   MESSAGE_ID=$(echo "$RESULT" | jq -r '.message_id')
   echo "Message ID: $MESSAGE_ID"
 else

--- a/tests/resources/models/getRetentionImageListResponse.json
+++ b/tests/resources/models/getRetentionImageListResponse.json
@@ -1,0 +1,16 @@
+{
+  "imageIdentifiers": [
+    {
+      "imageIdentifier": "test-image-1",
+      "imageState": "PENDING"
+    },
+    {
+      "imageIdentifier": "test-image-2",
+      "imageState": "APPROVED"
+    },
+    {
+      "imageIdentifier": "test-image-3",
+      "imageState": "REJECTED"
+    }
+  ]
+}

--- a/tests/resources/models/imageAlreadyExistsError.json
+++ b/tests/resources/models/imageAlreadyExistsError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4090002,
+  "errorMessage": "The image identifier already exists."
+}

--- a/tests/resources/models/imageInUseError.json
+++ b/tests/resources/models/imageInUseError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4030002,
+  "errorMessage": "The request is forbidden because the image is in use."
+}

--- a/tests/resources/models/imageNotFoundError.json
+++ b/tests/resources/models/imageNotFoundError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4040002,
+  "errorMessage": "The system can't find the image."
+}

--- a/tests/resources/models/invalidImageError.json
+++ b/tests/resources/models/invalidImageError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000104,
+  "errorMessage": "The request is invalid and can't be accepted."
+}

--- a/tests/test_api_client_async.py
+++ b/tests/test_api_client_async.py
@@ -43,6 +43,7 @@ from appstoreserverlibrary.models.UserStatus import UserStatus
 from appstoreserverlibrary.models.UploadMessageRequestBody import UploadMessageRequestBody
 from appstoreserverlibrary.models.UploadMessageImage import UploadMessageImage
 from appstoreserverlibrary.models.RetentionMessageState import RetentionMessageState
+from appstoreserverlibrary.models.ImageState import ImageState
 
 from tests.util import decode_json_from_signed_date, read_data_from_binary_file, read_data_from_file
 
@@ -716,6 +717,173 @@ class DecodedPayloads(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(4040001, e.raw_api_error)
             self.assertEqual(APIError.MESSAGE_NOT_FOUND_ERROR, e.api_error)
             self.assertEqual("An error that indicates the specified message was not found.", e.error_message)
+            return
+
+        self.assertFalse(True)
+
+    def get_client_with_binary_mock(self, response_body: bytes, expected_method: str, expected_url: str, expected_content_type: str, expected_binary_data: bytes, status_code: int = 200):
+        """Helper for testing async binary upload endpoints (e.g., image upload)."""
+        signing_key = self.get_signing_key()
+        client = AsyncAppStoreServerAPIClient(signing_key, 'keyId', 'issuerId', 'com.example', Environment.LOCAL_TESTING)
+
+        async def fake_binary_request(path: str, method: str, binary_data: bytes, content_type: str):
+            url = client._get_full_url(path)
+            self.assertEqual(expected_method, method)
+            self.assertEqual(expected_url, url)
+            self.assertEqual(expected_content_type, content_type)
+            self.assertEqual(expected_binary_data, binary_data)
+
+            # Simulate error handling from _make_binary_request
+            if not (200 <= status_code < 300):
+                if response_body:
+                    import json
+                    response_data = json.loads(response_body.decode('utf-8'))
+                    raise APIException(status_code, response_data.get('errorCode'), response_data.get('errorMessage'))
+                else:
+                    raise APIException(status_code)
+
+        client._make_binary_request = fake_binary_request
+        return client
+
+    async def test_upload_retention_image(self):
+        test_image_data = b'\x89PNG\r\n\x1a\n'  # Minimal PNG header
+        client = self.get_client_with_binary_mock(
+            b'',  # Empty response body for successful upload
+            'PUT',
+            'https://local-testing-base-url/inApps/v1/messaging/image/test-image-id',
+            'image/png',
+            test_image_data
+        )
+
+        # Should not raise exception for successful upload
+        await client.upload_retention_image('test-image-id', test_image_data)
+
+    async def test_upload_retention_image_already_exists_error(self):
+        test_image_data = b'\x89PNG\r\n\x1a\n'
+        error_body = read_data_from_binary_file('tests/resources/models/imageAlreadyExistsError.json')
+        client = self.get_client_with_binary_mock(
+            error_body,
+            'PUT',
+            'https://local-testing-base-url/inApps/v1/messaging/image/test-image-id',
+            'image/png',
+            test_image_data,
+            409
+        )
+
+        try:
+            await client.upload_retention_image('test-image-id', test_image_data)
+        except APIException as e:
+            self.assertEqual(409, e.http_status_code)
+            self.assertEqual(4090002, e.raw_api_error)
+            self.assertEqual(APIError.IMAGE_ALREADY_EXISTS_ERROR, e.api_error)
+            self.assertEqual("The image identifier already exists.", e.error_message)
+            return
+
+        self.assertFalse(True)
+
+    async def test_upload_retention_image_invalid_error(self):
+        test_image_data = b'invalid image data'
+        error_body = read_data_from_binary_file('tests/resources/models/invalidImageError.json')
+        client = self.get_client_with_binary_mock(
+            error_body,
+            'PUT',
+            'https://local-testing-base-url/inApps/v1/messaging/image/test-image-id',
+            'image/png',
+            test_image_data,
+            400
+        )
+
+        try:
+            await client.upload_retention_image('test-image-id', test_image_data)
+        except APIException as e:
+            self.assertEqual(400, e.http_status_code)
+            self.assertEqual(4000104, e.raw_api_error)
+            self.assertEqual(APIError.INVALID_IMAGE_ERROR, e.api_error)
+            self.assertEqual("The request is invalid and can't be accepted.", e.error_message)
+            return
+
+        self.assertFalse(True)
+
+    async def test_get_retention_image_list(self):
+        client = self.get_client_with_body_from_file(
+            'tests/resources/models/getRetentionImageListResponse.json',
+            'GET',
+            'https://local-testing-base-url/inApps/v1/messaging/image/list',
+            {},
+            None
+        )
+
+        response = await client.get_retention_image_list()
+
+        self.assertIsNotNone(response)
+        self.assertIsNotNone(response.imageIdentifiers)
+        self.assertEqual(3, len(response.imageIdentifiers))
+
+        # Check first image
+        image1 = response.imageIdentifiers[0]
+        self.assertEqual('test-image-1', image1.imageIdentifier)
+        self.assertEqual(ImageState.PENDING, image1.imageState)
+
+        # Check second image
+        image2 = response.imageIdentifiers[1]
+        self.assertEqual('test-image-2', image2.imageIdentifier)
+        self.assertEqual(ImageState.APPROVED, image2.imageState)
+
+        # Check third image
+        image3 = response.imageIdentifiers[2]
+        self.assertEqual('test-image-3', image3.imageIdentifier)
+        self.assertEqual(ImageState.REJECTED, image3.imageState)
+
+    async def test_delete_retention_image(self):
+        client = self.get_client_with_body(
+            b'',
+            'DELETE',
+            'https://local-testing-base-url/inApps/v1/messaging/image/test-image-id',
+            {},
+            None
+        )
+
+        # Should not raise exception for successful deletion
+        await client.delete_retention_image('test-image-id')
+
+    async def test_delete_retention_image_not_found_error(self):
+        client = self.get_client_with_body_from_file(
+            'tests/resources/models/imageNotFoundError.json',
+            'DELETE',
+            'https://local-testing-base-url/inApps/v1/messaging/image/nonexistent-image-id',
+            {},
+            None,
+            404
+        )
+
+        try:
+            await client.delete_retention_image('nonexistent-image-id')
+        except APIException as e:
+            self.assertEqual(404, e.http_status_code)
+            self.assertEqual(4040002, e.raw_api_error)
+            self.assertEqual(APIError.IMAGE_NOT_FOUND_ERROR, e.api_error)
+            self.assertEqual("The system can't find the image.", e.error_message)
+            return
+
+        self.assertFalse(True)
+
+    async def test_delete_retention_image_in_use_error(self):
+        client = self.get_client_with_body_from_file(
+            'tests/resources/models/imageInUseError.json',
+            'DELETE',
+            'https://local-testing-base-url/inApps/v1/messaging/image/image-in-use',
+            {},
+            None,
+            403
+        )
+
+        try:
+            await client.delete_retention_image('image-in-use')
+        except APIException as e:
+            self.assertEqual(403, e.http_status_code)
+            self.assertEqual(4030002, e.raw_api_error)
+            self.assertEqual(APIError.IMAGE_IN_USE_ERROR, e.api_error)
+            self.assertEqual("The request is forbidden because the image is in use.", e.error_message)
             return
 
         self.assertFalse(True)


### PR DESCRIPTION
this PR adds support for managing images: https://developer.apple.com/documentation/retentionmessaging/upload-image

also updates the cli README examples to be more contextually appropriate 

upstream PR here: https://github.com/apple/app-store-server-library-python/pull/159